### PR TITLE
Changed to use static regex rather than rely on the regex cache

### DIFF
--- a/src/HtmlTags/Conventions/Elements/Builders/DefaultLabelBuilder.cs
+++ b/src/HtmlTags/Conventions/Elements/Builders/DefaultLabelBuilder.cs
@@ -5,6 +5,13 @@ namespace HtmlTags.Conventions.Elements.Builders
 
     public class DefaultLabelBuilder : IElementBuilder
     {
+        private static readonly Regex[] RxPatterns =
+        {
+            new Regex("([a-z])([A-Z])", RegexOptions.IgnorePatternWhitespace),
+            new Regex("([0-9])([a-zA-Z])", RegexOptions.IgnorePatternWhitespace),
+            new Regex("([a-zA-Z])([0-9])", RegexOptions.IgnorePatternWhitespace)
+        };
+
         public bool Matches(ElementRequest subject) => true;
 
         public HtmlTag Build(ElementRequest request)
@@ -14,14 +21,8 @@ namespace HtmlTags.Conventions.Elements.Builders
 
         public static string BreakUpCamelCase(string fieldName)
         {
-            var patterns = new[]
-                {
-                    "([a-z])([A-Z])",
-                    "([0-9])([a-zA-Z])",
-                    "([a-zA-Z])([0-9])"
-                };
-            var output = patterns.Aggregate(fieldName,
-                (current, pattern) => Regex.Replace(current, pattern, "$1 $2", RegexOptions.IgnorePatternWhitespace));
+            var output = RxPatterns.Aggregate(fieldName,
+                (current, regex) => regex.Replace(current, "$1 $2"));
             return output.Replace('_', ' ');
         }
     }

--- a/src/HtmlTags/HtmlTag.cs
+++ b/src/HtmlTags/HtmlTag.cs
@@ -17,6 +17,7 @@ namespace HtmlTags
 
         public static HtmlTag Placeholder() => new HtmlTag().NoTag();
 
+        private static readonly Regex RxWhiteSpace = new Regex("[ ]+");
         private const string CssClassAttribute = "class";
         private const string CssStyleAttribute = "style";
         private const string DataPrefix = "data-";
@@ -647,7 +648,7 @@ namespace HtmlTags
             }
             else
             {
-                classes = Regex.Split(className, "[ ]+")
+                classes = RxWhiteSpace.Split(className)
                                .Where(c => !string.IsNullOrWhiteSpace(c));
             }
 


### PR DESCRIPTION
Changed to use static regex rather than rely on the regex cache as these are used all the time, so eliminating the cache can be a big performance win for our code. Originally we moved all our regular expressions to be compiled, but during performance tuning found those to have significant thread locking issues causing performance degradation on our web site, so we removed that. I don't believe that has been improved recently.

Sorry it took me 6 years to get back around to this, but we have been using our own custom build of HtmlTags all these years, and we are trying to move to ASP.Net Core, so had to port this to .Net Standard so want to get back to using the official version again.