### PR TITLE
Append text

### DIFF
--- a/src/HtmlTags/Cache.cs
+++ b/src/HtmlTags/Cache.cs
@@ -7,7 +7,7 @@ namespace HtmlTags
 {
     internal class Cache<TKey, TValue> : IEnumerable<TValue> where TValue : class
     {
-        private readonly object _locker = new object();
+        private readonly object _locker = new();
         private readonly IDictionary<TKey, TValue> _values;
 
         private Func<TValue, TKey> _getKey = arg => { throw new NotImplementedException(); };

--- a/src/HtmlTags/CachedExpressionCompiler.cs
+++ b/src/HtmlTags/CachedExpressionCompiler.cs
@@ -37,13 +37,13 @@ namespace HtmlTags
             private static Func<TModel, object> _identityFunc;
 
             private static readonly ConcurrentDictionary<MemberInfo, Func<TModel, object>> _simpleMemberAccessCache =
-                new ConcurrentDictionary<MemberInfo, Func<TModel, object>>();
+                new();
 
             private static readonly ConcurrentDictionary<MemberExpressionCacheKey, Func<TModel, object>> _chainedMemberAccessCache =
-                new ConcurrentDictionary<MemberExpressionCacheKey, Func<TModel, object>>(MemberExpressionCacheKeyComparer.Instance);
+                new(MemberExpressionCacheKeyComparer.Instance);
 
             private static readonly ConcurrentDictionary<MemberInfo, Func<object, TResult>> _constMemberAccessCache =
-                new ConcurrentDictionary<MemberInfo, Func<object, TResult>>();
+                new();
 
             public static Func<TModel, object> Compile(Expression<Func<TModel, TResult>> expression)
             {

--- a/src/HtmlTags/Conventions/BuilderSet.cs
+++ b/src/HtmlTags/Conventions/BuilderSet.cs
@@ -8,8 +8,8 @@ namespace HtmlTags.Conventions
     // Tested through the test for TagCategory and TagLibrary
     public class BuilderSet : ITagBuildingExpression
     {
-        private readonly List<ITagBuilderPolicy> _policies = new List<ITagBuilderPolicy>();
-        private readonly List<ITagModifier> _modifiers = new List<ITagModifier>();
+        private readonly List<ITagBuilderPolicy> _policies = new();
+        private readonly List<ITagModifier> _modifiers = new();
         private IElementNamingConvention _elementNamingConvention;
 
         public BuilderSet()
@@ -34,9 +34,9 @@ namespace HtmlTags.Conventions
         public void NamingConvention(IElementNamingConvention elementNamingConvention) 
             => _elementNamingConvention = elementNamingConvention;
 
-        public CategoryExpression Always => new CategoryExpression(this, x => true);
+        public CategoryExpression Always => new(this, x => true);
 
-        public CategoryExpression If(Func<ElementRequest, bool> matches) => new CategoryExpression(this, matches);
+        public CategoryExpression If(Func<ElementRequest, bool> matches) => new(this, matches);
 
         public void Import(BuilderSet other)
         {

--- a/src/HtmlTags/Conventions/ElementCategoryExpression.cs
+++ b/src/HtmlTags/Conventions/ElementCategoryExpression.cs
@@ -26,10 +26,10 @@ namespace HtmlTags.Conventions
         public void NamingConvention(IElementNamingConvention elementNamingConvention)
             => _set.NamingConvention(elementNamingConvention);
 
-        public ElementActionExpression Always => new ElementActionExpression(_set, req => true, "Always");
+        public ElementActionExpression Always => new(_set, req => true, "Always");
 
         public ElementActionExpression If(Func<ElementRequest, bool> matches, string description = null) 
-            => new ElementActionExpression(_set, matches, description);
+            => new(_set, matches, description);
 
         public ElementActionExpression IfPropertyIs<T>() => If(req => req.Accessor.PropertyType == typeof(T),
             $"Property type is {typeof (T).Name}");

--- a/src/HtmlTags/Conventions/ElementGenerator.cs
+++ b/src/HtmlTags/Conventions/ElementGenerator.cs
@@ -50,7 +50,7 @@ namespace HtmlTags.Conventions
 
         public ElementRequest GetRequest<TResult>(Expression<Func<T, TResult>> expression, T model = null)
         {
-            return new ElementRequest(expression.ToAccessor())
+            return new(expression.ToAccessor())
             {
                 Model = model ?? Model
             };

--- a/src/HtmlTags/Conventions/ElementRequest.cs
+++ b/src/HtmlTags/Conventions/ElementRequest.cs
@@ -52,7 +52,7 @@ namespace HtmlTags.Conventions
             CurrentTag = tag;
         }
 
-        public AccessorDef ToAccessorDef() => new AccessorDef(Accessor, HolderType());
+        public AccessorDef ToAccessorDef() => new(Accessor, HolderType());
 
 
         public Type HolderType() => Model == null ? Accessor.DeclaringType : Model?.GetType();
@@ -79,6 +79,6 @@ namespace HtmlTags.Conventions
 
         public void Attach(Func<Type, object> locator) => _services = locator;
 
-        public ElementRequest ToToken() => new ElementRequest(Accessor);
+        public ElementRequest ToToken() => new(Accessor);
     }
 }

--- a/src/HtmlTags/Conventions/Elements/AccessorDef.cs
+++ b/src/HtmlTags/Conventions/Elements/AccessorDef.cs
@@ -17,7 +17,7 @@ namespace HtmlTags.Conventions.Elements
 
         public static AccessorDef For<T>(Expression<Func<T, object>> expression)
         {
-            return new AccessorDef(expression.ToAccessor(), typeof(T));
+            return new(expression.ToAccessor(), typeof(T));
         }
 
         public bool Equals(AccessorDef other)

--- a/src/HtmlTags/Conventions/Elements/Builders/DefaultIdBuilder.cs
+++ b/src/HtmlTags/Conventions/Elements/Builders/DefaultIdBuilder.cs
@@ -4,7 +4,7 @@ namespace HtmlTags.Conventions.Elements.Builders
 {
     public class DefaultIdBuilder
     {
-        private static readonly Regex IdRegex = new Regex(@"[\.\[\]]");
+        private static readonly Regex IdRegex = new(@"[\.\[\]]");
 
         public static string Build(ElementRequest request) 
             => IdRegex.Replace(request.ElementId, "_");

--- a/src/HtmlTags/Conventions/Elements/Builders/DefaultLabelBuilder.cs
+++ b/src/HtmlTags/Conventions/Elements/Builders/DefaultLabelBuilder.cs
@@ -7,9 +7,9 @@ namespace HtmlTags.Conventions.Elements.Builders
     {
         private static readonly Regex[] RxPatterns =
         {
-            new Regex("([a-z])([A-Z])", RegexOptions.IgnorePatternWhitespace),
-            new Regex("([0-9])([a-zA-Z])", RegexOptions.IgnorePatternWhitespace),
-            new Regex("([a-zA-Z])([0-9])", RegexOptions.IgnorePatternWhitespace)
+            new("([a-z])([A-Z])", RegexOptions.IgnorePatternWhitespace),
+            new("([0-9])([a-zA-Z])", RegexOptions.IgnorePatternWhitespace),
+            new("([a-zA-Z])([0-9])", RegexOptions.IgnorePatternWhitespace)
         };
 
         public bool Matches(ElementRequest subject) => true;

--- a/src/HtmlTags/Conventions/Formatting/DisplayConversionRegistry.cs
+++ b/src/HtmlTags/Conventions/Formatting/DisplayConversionRegistry.cs
@@ -21,7 +21,7 @@ namespace HtmlTags.Conventions.Formatting
 
         private MakeDisplayExpression MakeDisplay(Func<GetStringRequest, bool> filter)
         {
-            return new MakeDisplayExpression(func =>
+            return new(func =>
             {
                 _strategies.Add(new StringifierStrategy
                 {
@@ -33,7 +33,7 @@ namespace HtmlTags.Conventions.Formatting
 
         private MakeDisplayExpression<T> MakeDisplay<T>(Func<GetStringRequest, bool> filter)
         {
-            return new MakeDisplayExpression<T>(func =>
+            return new(func =>
             {
                 _strategies.Add(new StringifierStrategy
                 {

--- a/src/HtmlTags/Conventions/Formatting/GetStringRequest.cs
+++ b/src/HtmlTags/Conventions/Formatting/GetStringRequest.cs
@@ -84,7 +84,7 @@ namespace HtmlTags.Conventions.Formatting
 
         public GetStringRequest GetRequestForNullableType()
         {
-            return new GetStringRequest(OwnerType, Property, RawValue, Format, PropertyType.GetInnerTypeFromNullable())
+            return new(OwnerType, Property, RawValue, Format, PropertyType.GetInnerTypeFromNullable())
             {
                 Locator = Locator
             };
@@ -92,7 +92,7 @@ namespace HtmlTags.Conventions.Formatting
 
         public GetStringRequest GetRequestForElementType()
         {
-            return new GetStringRequest(OwnerType, Property, RawValue, Format, PropertyType.GetElementType())
+            return new(OwnerType, Property, RawValue, Format, PropertyType.GetElementType())
             {
                 Locator = Locator,
             };

--- a/src/HtmlTags/Conventions/Formatting/Stringifier.cs
+++ b/src/HtmlTags/Conventions/Formatting/Stringifier.cs
@@ -7,8 +7,8 @@ namespace HtmlTags.Conventions.Formatting
 
     public class Stringifier
 	{
-        private readonly List<PropertyOverrideStrategy> _overrides = new List<PropertyOverrideStrategy>();
-        private readonly List<StringifierStrategy> _strategies = new List<StringifierStrategy>();
+        private readonly List<PropertyOverrideStrategy> _overrides = new();
+        private readonly List<StringifierStrategy> _strategies = new();
 
         private Func<GetStringRequest, string> findConverter(GetStringRequest request)
         {

--- a/src/HtmlTags/Conventions/HtmlConventionLibrary.cs
+++ b/src/HtmlTags/Conventions/HtmlConventionLibrary.cs
@@ -6,7 +6,7 @@ namespace HtmlTags.Conventions
 
     public class HtmlConventionLibrary
     {
-        private readonly Cache<string, ServiceBuilder> _services = new Cache<string, ServiceBuilder>(key => new ServiceBuilder());
+        private readonly Cache<string, ServiceBuilder> _services = new(key => new ServiceBuilder());
         private readonly ServiceBuilder _defaultBuilder;
 
         public HtmlConventionLibrary()

--- a/src/HtmlTags/Conventions/ProfileExpression.cs
+++ b/src/HtmlTags/Conventions/ProfileExpression.cs
@@ -15,13 +15,13 @@ namespace HtmlTags.Conventions
 
         private BuilderSet BuildersFor(string category) => Library.TagLibrary.Category(category).Profile(_profileName);
 
-        public ElementCategoryExpression Labels => new ElementCategoryExpression(BuildersFor(ElementConstants.Label));
+        public ElementCategoryExpression Labels => new(BuildersFor(ElementConstants.Label));
 
-        public ElementCategoryExpression Displays => new ElementCategoryExpression(BuildersFor(ElementConstants.Display));
+        public ElementCategoryExpression Displays => new(BuildersFor(ElementConstants.Display));
 
-        public ElementCategoryExpression Editors => new ElementCategoryExpression(BuildersFor(ElementConstants.Editor));
+        public ElementCategoryExpression Editors => new(BuildersFor(ElementConstants.Editor));
 
-        public ElementCategoryExpression ValidationMessages => new ElementCategoryExpression(BuildersFor(ElementConstants.ValidationMessage));
+        public ElementCategoryExpression ValidationMessages => new(BuildersFor(ElementConstants.ValidationMessage));
 
         public void Apply(HtmlConventionLibrary library) => library.Import(Library);
     }

--- a/src/HtmlTags/Conventions/ServiceBuilder.cs
+++ b/src/HtmlTags/Conventions/ServiceBuilder.cs
@@ -4,7 +4,7 @@ namespace HtmlTags.Conventions
 {
     public class ServiceBuilder
     {
-        private readonly Cache<Type, object> _services = new Cache<Type, object>();
+        private readonly Cache<Type, object> _services = new();
 
         public bool Has(Type type) => _services.Has(type);
 

--- a/src/HtmlTags/Conventions/TagCategory.cs
+++ b/src/HtmlTags/Conventions/TagCategory.cs
@@ -7,14 +7,14 @@ namespace HtmlTags.Conventions
     public class TagCategory : ITagBuildingExpression
     {
         private readonly Cache<string, BuilderSet> _profiles =
-            new Cache<string, BuilderSet>(name => new BuilderSet());
+            new(name => new BuilderSet());
 
         public TagCategory()
         {
             _profiles[TagConstants.Default] = Defaults;
         }
 
-        public BuilderSet Defaults { get; } = new BuilderSet();
+        public BuilderSet Defaults { get; } = new();
 
         public BuilderSet Profile(string name) => _profiles[name];
 

--- a/src/HtmlTags/Conventions/TagGenerator.cs
+++ b/src/HtmlTags/Conventions/TagGenerator.cs
@@ -5,7 +5,7 @@ namespace HtmlTags.Conventions
 {
     public class ActiveProfile
     {
-        private readonly Stack<string> _profiles = new Stack<string>();
+        private readonly Stack<string> _profiles = new();
 
         public ActiveProfile()
         {

--- a/src/HtmlTags/Conventions/TagLibrary.cs
+++ b/src/HtmlTags/Conventions/TagLibrary.cs
@@ -11,7 +11,7 @@ namespace HtmlTags.Conventions
     public class TagLibrary : ITagBuildingExpression, ITagLibrary
     {
         private readonly Cache<string, TagCategory> _categories =
-            new Cache<string, TagCategory>(name => new TagCategory());
+            new(name => new TagCategory());
 
         public ITagPlan PlanFor(ElementRequest subject, string profile = null, string category = null)
         {

--- a/src/HtmlTags/Conventions/TagPlan.cs
+++ b/src/HtmlTags/Conventions/TagPlan.cs
@@ -11,7 +11,7 @@ namespace HtmlTags.Conventions
 
     public class TagPlan : ITagPlan
     {
-        private readonly List<ITagModifier> _modifiers = new List<ITagModifier>();
+        private readonly List<ITagModifier> _modifiers = new();
 
         public TagPlan(ITagBuilder builder, IEnumerable<ITagModifier> modifiers, IElementNamingConvention elementNamingConvention)
         {

--- a/src/HtmlTags/CssClassNameValidator.cs
+++ b/src/HtmlTags/CssClassNameValidator.cs
@@ -8,9 +8,9 @@ namespace HtmlTags
         public const string ValidStartRegex = @"^-?[_a-zA-Z]+";
         public const string InvalidStartRegex = @"^-?[^_a-zA-Z]+";
         public const string ValidClassChars = @"_a-zA-Z0-9-";
-        private static readonly Regex RxValidClassName = new Regex($@"{ValidStartRegex}[{ValidClassChars}]*$");
-        private static readonly Regex RxReplaceInvalidChars = new Regex($"[^{ValidClassChars}]");
-        private static readonly Regex RxReplaceLeadingChars = new Regex($"{InvalidStartRegex}(?<rest>.*)$");
+        private static readonly Regex RxValidClassName = new($@"{ValidStartRegex}[{ValidClassChars}]*$");
+        private static readonly Regex RxReplaceInvalidChars = new($"[^{ValidClassChars}]");
+        private static readonly Regex RxReplaceLeadingChars = new($"{InvalidStartRegex}(?<rest>.*)$");
 
         public static bool AllowInvalidCssClassNames { get; set; }
 

--- a/src/HtmlTags/HtmlDocument.cs
+++ b/src/HtmlTags/HtmlDocument.cs
@@ -8,9 +8,9 @@ namespace HtmlTags
 {
     public class HtmlDocument
     {
-        private readonly List<Func<string, string>> _alterations = new List<Func<string, string>>();
+        private readonly List<Func<string, string>> _alterations = new();
 
-        private readonly Stack<HtmlTag> _currentStack = new Stack<HtmlTag>();
+        private readonly Stack<HtmlTag> _currentStack = new();
         private readonly HtmlTag _title;
 
         public HtmlDocument()

--- a/src/HtmlTags/HtmlHelperExtensions.cs
+++ b/src/HtmlTags/HtmlHelperExtensions.cs
@@ -17,7 +17,7 @@ namespace HtmlTags
 
     public static class HtmlHelperExtensions
     {
-        private static readonly DotNotationElementNamingConvention NamingConvention = new DotNotationElementNamingConvention();
+        private static readonly DotNotationElementNamingConvention NamingConvention = new();
 
         public static HtmlTag Input<T, TResult>(this IHtmlHelper<T> helper, Expression<Func<T, TResult>> expression)
             where T : class

--- a/src/HtmlTags/HtmlTag.cs
+++ b/src/HtmlTags/HtmlTag.cs
@@ -17,12 +17,12 @@ namespace HtmlTags
 
         public static HtmlTag Placeholder() => new HtmlTag().NoTag();
 
-        private static readonly Regex RxWhiteSpace = new Regex("[ ]+");
+        private static readonly Regex RxWhiteSpace = new("[ ]+");
         private const string CssClassAttribute = "class";
         private const string CssStyleAttribute = "style";
         private const string DataPrefix = "data-";
         private static string _metadataSuffix = "__";
-        private static readonly HashSet<string> _voidElementTags = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        private static readonly HashSet<string> _voidElementTags = new(StringComparer.OrdinalIgnoreCase)
         {
             "area",
             "base",
@@ -47,13 +47,13 @@ namespace HtmlTags
 
         public static string MetadataAttribute => DataPrefix + _metadataSuffix;
 
-        private readonly List<HtmlTag> _children = new List<HtmlTag>();
-        private readonly HashSet<string> _cssClasses = new HashSet<string>();
+        private readonly List<HtmlTag> _children = new();
+        private readonly HashSet<string> _cssClasses = new();
         private readonly IDictionary<string, string> _customStyles = new Dictionary<string, string>();
 
-        private readonly Cache<string, HtmlAttribute> _htmlAttributes = new Cache<string, HtmlAttribute>(key => null);
+        private readonly Cache<string, HtmlAttribute> _htmlAttributes = new(key => null);
 
-        private readonly Cache<string, object> _metaData = new Cache<string, object>();
+        private readonly Cache<string, object> _metaData = new();
         private string _innerText = String.Empty;
         private bool _shouldRender = true;
         private string _tag;
@@ -360,8 +360,9 @@ namespace HtmlTags
 
         public HtmlTag AppendText(string text)
         {
-            _innerText += text;
-            return this;
+            var textTag = new HtmlTag().NoTag().Text(text);
+
+            return Append(textTag);
         }
 
         public HtmlTag MergeAttributes(IDictionary<string, string> attributes)

--- a/src/HtmlTags/HtmlTagExtensions.cs
+++ b/src/HtmlTags/HtmlTagExtensions.cs
@@ -4,6 +4,6 @@ namespace HtmlTags
 {
     public static class HtmlTagExtensions
     {
-        public static TagList ToTagList(this IEnumerable<HtmlTag> tags) => new TagList(tags);
+        public static TagList ToTagList(this IEnumerable<HtmlTag> tags) => new(tags);
     }
 }

--- a/src/HtmlTags/MemberExpressionCacheKey.cs
+++ b/src/HtmlTags/MemberExpressionCacheKey.cs
@@ -45,7 +45,7 @@ namespace HtmlTags
 
         public MemberInfo[] Members { get; }
 
-        public Enumerator GetEnumerator() => new Enumerator(this);
+        public Enumerator GetEnumerator() => new(this);
 
         public struct Enumerator
         {

--- a/src/HtmlTags/MemberExpressionCacheKeyComparer.cs
+++ b/src/HtmlTags/MemberExpressionCacheKeyComparer.cs
@@ -9,7 +9,7 @@ namespace HtmlTags
 {
     internal class MemberExpressionCacheKeyComparer : IEqualityComparer<MemberExpressionCacheKey>
     {
-        public static readonly MemberExpressionCacheKeyComparer Instance = new MemberExpressionCacheKeyComparer();
+        public static readonly MemberExpressionCacheKeyComparer Instance = new();
 
         public bool Equals(MemberExpressionCacheKey x, MemberExpressionCacheKey y)
         {

--- a/src/HtmlTags/Reflection/AccessorRules.cs
+++ b/src/HtmlTags/Reflection/AccessorRules.cs
@@ -8,7 +8,7 @@
     public class AccessorRules
     {
         private readonly Cache<Type, Cache<Accessor, IList<object>>> _rules =
-            new Cache<Type, Cache<Accessor, IList<object>>>(
+            new(
                 type => new Cache<Accessor, IList<object>>(a => new List<object>()));
 
         public void Add(Accessor accessor, object rule) 

--- a/src/HtmlTags/Reflection/Expressions/OrOperation.cs
+++ b/src/HtmlTags/Reflection/Expressions/OrOperation.cs
@@ -7,7 +7,7 @@ namespace HtmlTags.Reflection.Expressions
 {
     public class ComposableOrOperation
     {
-        private readonly List<Tuple<IPropertyOperation, MemberExpression, object>> _listOfOperations = new List<Tuple<IPropertyOperation, MemberExpression, object>>();
+        private readonly List<Tuple<IPropertyOperation, MemberExpression, object>> _listOfOperations = new();
 
         public void Set<T>(Expression<Func<T, object>> path, object value)
         {

--- a/src/HtmlTags/ServiceCollectionExtensions.cs
+++ b/src/HtmlTags/ServiceCollectionExtensions.cs
@@ -1,8 +1,8 @@
-﻿namespace HtmlTags
+﻿namespace Microsoft.Extensions.DependencyInjection
 {
     using System;
-    using Conventions;
-    using Microsoft.Extensions.DependencyInjection;
+    using HtmlTags;
+    using HtmlTags.Conventions;
 
     public static class ServiceCollectionExtensions
     {

--- a/src/HtmlTags/TableTag.cs
+++ b/src/HtmlTags/TableTag.cs
@@ -90,10 +90,10 @@ namespace HtmlTags
 
         public HtmlTag Header(string text) => new HtmlTag("th", this).Text(text);
 
-        public HtmlTag Header() => new HtmlTag("th", this);
+        public HtmlTag Header() => new("th", this);
 
         public HtmlTag Cell(string text) => new HtmlTag("td", this).Text(text);
 
-        public HtmlTag Cell() => new HtmlTag("td", this);
+        public HtmlTag Cell() => new("td", this);
     }
 }

--- a/test/HtmlTags.Testing/HtmlTagTester.cs
+++ b/test/HtmlTags.Testing/HtmlTagTester.cs
@@ -47,6 +47,13 @@ namespace HtmlTags.Testing
         }
 
         [Fact]
+        public void appending_inner_text_with_tags()
+        {
+            var tag = new HtmlTag("p").AppendText("some text").Append("span").AppendText("more text");
+            tag.ToString().ShouldBe("<p>some text<span></span>more text</p>");
+        }
+
+        [Fact]
         public void the_inner_text_is_html_encoded_by_default()
         {
             var tag = new HtmlTag("div");


### PR DESCRIPTION
Append text now appends text as a `NoTag` tag, so that you can mix appends of tags and text.

This means that `Text` will not clear out text from `AppendText`.